### PR TITLE
docs: Consolidate development documentation and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,266 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+This project uses [mise](https://mise.jdx.dev/) for tool management and task running.
+
+```bash
+# Install all development tools (Go, golangci-lint, nerdctl, soci)
+mise install
+
+# Build the binary
+mise run build
+
+# Run unit tests
+mise run test
+
+# Run unit tests with coverage
+mise run test-coverage
+
+# Run integration tests (requires Docker)
+mise run integration-test
+
+# Run linter
+mise run lint
+
+# Format code
+mise run fmt
+
+# Check for dead code
+mise run deadcode
+
+# Clean build artifacts
+mise run clean
+
+# See all available tasks
+mise tasks
+```
+
+### Running Single Tests
+
+```bash
+# Run a specific test function
+go test -v ./internal/estargz -run TestExtractFile
+
+# Run tests in a specific package
+go test -v ./internal/soci/...
+
+# Run with race detector
+go test -race ./...
+```
+
+## Architecture Overview
+
+oci-extract extracts files from OCI/Docker images **without mounting them or downloading entire images**. The core innovation is using **HTTP Range requests** to fetch only the necessary bytes.
+
+### The "No-Mount" Strategy
+
+```
+Traditional:        docker pull → mount → copy file → 500MB downloaded
+oci-extract:        fetch metadata → range request → ~50KB downloaded
+```
+
+The tool processes image layers from **top to bottom** (respecting OCI overlay semantics) and tries increasingly efficient extraction strategies with graceful fallback:
+
+1. **eStargz** (fastest): Read TOC → Range request specific chunks
+2. **SOCI** (fast): Read zTOC → Range request compressed ranges
+3. **Standard** (fallback): Stream entire layer (still avoids pulling to local storage)
+
+### High-Level Flow
+
+```
+CLI Command (cmd/)
+    ↓
+Orchestrator (extractor/orchestrator.go)
+    ├─ Registry Client → Fetch manifest, construct blob URLs
+    ├─ SOCI Discovery → Find SOCI indices (optional)
+    └─ For each layer (bottom-up):
+        ├─ Format Detection → Minimal detection, mostly try-and-fallback
+        ├─ Try eStargz extraction
+        ├─ Try SOCI extraction (if index exists)
+        └─ Fallback to standard extraction
+            ↓
+Remote Reader (remote/reader.go)
+    └─ HTTP Range requests to blob URLs
+```
+
+## Key Code Architecture
+
+### Critical Components
+
+#### 1. **Orchestrator** (`internal/extractor/orchestrator.go`)
+The brain of the operation. Coordinates format detection, layer iteration, and extractor selection.
+
+**Important patterns:**
+- Processes layers in **reverse order** (index len-1 to 0) to respect overlay semantics
+- Uses **optimistic trying**: attempts efficient formats first, degrades gracefully
+- Returns on **first successful extraction** (top layer wins)
+
+#### 2. **Remote Reader** (`internal/remote/reader.go`)
+Implements `io.ReaderAt` for HTTP Range requests. This is the **secret sauce** that enables efficient extraction.
+
+**Key insight:** The reader bypasses go-containerregistry's streaming `io.ReadCloser` API to enable random access:
+
+```go
+// ❌ What we DON'T do:
+layer.Compressed() // Must stream from start, no seeking
+
+// ✅ What we DO:
+RemoteReader(blobURL).ReadAt(offset, length) // Random access!
+```
+
+Includes a simple 1MB cache to reduce redundant requests for metadata reads.
+
+#### 3. **Registry Client** (`internal/registry/client.go`)
+Handles OCI registry operations and constructs direct blob URLs.
+
+**Critical function:** `GetLayerURL()` constructs the blob URL that RemoteReader uses:
+```
+https://{registry}/v2/{repository}/blobs/{digest}
+```
+
+**Important:** Handles Docker Hub's registry domain mapping (`index.docker.io` → `registry-1.docker.io`).
+
+#### 4. **EnhancedLayerInfo** (`internal/registry/client.go`)
+Bundles layer metadata with its direct blob URL. This structure is the handoff between registry operations and extraction.
+
+```go
+type EnhancedLayerInfo struct {
+    Layer     v1.Layer  // go-containerregistry layer object
+    Digest    v1.Hash
+    Size      int64
+    MediaType string
+    BlobURL   string    // Critical: enables RemoteReader
+}
+```
+
+#### 5. **Format Extractors**
+Three packages implement the same conceptual interface (not formally defined):
+
+- `internal/estargz/extractor.go`: eStargz format (TOC-based)
+- `internal/soci/extractor.go`: SOCI format (zTOC-based)
+- `internal/standard/extractor.go`: Standard tar.gz layers
+
+Each provides:
+```go
+ExtractFile(ctx, targetPath, outputPath) error
+ListFiles(ctx) ([]string, error)
+```
+
+**Design decision:** No explicit Go interface. This is intentional pragmatism - each extractor has different constructor needs and format-specific optimizations.
+
+#### 6. **SOCI Discovery** (`internal/soci/discovery.go`)
+Finds SOCI indices via two methods:
+
+1. **OCI 1.1 Referrers API** (modern, standard)
+2. **Tag-based naming** (fallback: `sha256-{digest}.soci`)
+
+Supporting both maximizes registry compatibility.
+
+### Data Flow: Extract Command
+
+```
+1. cmd/extract.go:runExtract()
+   └─ Parse args, create Orchestrator
+
+2. orchestrator.Extract()
+   ├─ client.GetEnhancedLayers(imageRef)
+   │  ├─ Authenticate via Docker keychain
+   │  ├─ Fetch manifest
+   │  └─ Construct blob URLs for each layer
+   │
+   ├─ soci.DiscoverSOCIIndex() [if applicable]
+   │
+   └─ For each layer (reverse order):
+      ├─ Try eStargz:
+      │  └─ RemoteReader → Read footer → Read TOC → Range request chunks
+      │
+      ├─ Try SOCI:
+      │  └─ RemoteReader → Read zTOC → Range request compressed ranges
+      │
+      └─ Fallback Standard:
+         └─ Stream layer → Decompress → Iterate tar → Extract file
+```
+
+### Data Flow: List Command
+
+Same as Extract, but:
+- Calls `ListFiles()` instead of `ExtractFile()`
+- Accumulates files across all layers
+- De-duplicates (upper layers override lower)
+- No early exit (must check all layers)
+
+## Important Design Decisions
+
+### 1. Separation of Metadata and Blob Access
+The orchestrator uses `v1.Layer` for metadata but accesses actual data via `RemoteReader(blobURL)`. This bypasses the streaming-only `v1.Layer` interface to enable random access.
+
+### 2. Format Detection is Minimal
+`detector/format.go` does basic detection, but the real strategy is **try-and-fallback**. Failed format attempts are cheap (just TOC/zTOC header checks), so optimistic trying is efficient.
+
+### 3. Bottom-Up Layer Processing
+```go
+for i := len(layers) - 1; i >= 0; i-- {
+    // Process from top to bottom
+}
+```
+This respects OCI overlay semantics: upper layers override lower layers.
+
+### 4. Authentication Piggybacks on Initial Fetch
+- Initial manifest/layer fetch authenticates via Docker keychain
+- OAuth/Bearer tokens cached in HTTP client
+- Subsequent Range requests automatically include auth headers
+- No re-authentication needed for blob URLs
+
+### 5. No Explicit Extractor Interface
+Extractors follow a common pattern but don't implement a formal Go interface. This allows format-specific optimizations and different constructor signatures while keeping the code pragmatic.
+
+### 6. Simple 1MB Cache in RemoteReader
+Instead of complex LRU caching, RemoteReader uses a single 1MB buffer cache. This is sufficient for typical TOC/zTOC reads and keeps the implementation simple.
+
+## Working with Extractors
+
+When adding support for a new format:
+
+1. Create package under `internal/newformat/`
+2. Implement `ExtractFile(ctx, targetPath, outputPath)` and `ListFiles(ctx)`
+3. Add detection logic in `internal/detector/format.go`
+4. Wire into orchestrator in `internal/extractor/orchestrator.go:extractFromLayer()`
+5. Add to the try-and-fallback chain with appropriate priority
+
+**Testing strategy:**
+- Unit tests: Mock layers, test extraction logic
+- Integration tests: Use real images (see `tests/integration/`)
+- Integration tests build images with different formats using nerdctl and soci tools
+
+## Important External Dependencies
+
+- **google/go-containerregistry**: OCI registry client, manifest/layer operations
+- **containerd/stargz-snapshotter**: eStargz format support (TOC parsing)
+- **awslabs/soci-snapshotter**: SOCI format support (zTOC parsing)
+- **spf13/cobra**: CLI framework
+
+The tool is a thin orchestration layer that combines these libraries with custom HTTP Range request handling.
+
+## Common Gotchas
+
+### Docker Hub Registry Domain
+Docker Hub uses different domains for API and blob storage:
+- API/Auth: `index.docker.io`
+- Blob storage: `registry-1.docker.io`
+
+The registry client handles this mapping in `GetLayerURL()`.
+
+### Layer Order Matters
+Always process layers from **high index to low index** (reverse order of the slice). This is the opposite of what might seem intuitive but matches overlay filesystem semantics.
+
+### BlobURL is Critical
+The `EnhancedLayerInfo.BlobURL` must be correct for RemoteReader to work. If you see "404 Not Found" errors, check the blob URL construction logic.
+
+### SOCI Indices Are Optional
+The tool works without SOCI indices (falls back to eStargz or standard). Don't treat missing SOCI indices as errors unless the user explicitly requested `--format soci`.
+
+### Range Request Requirements
+Some registries might not support HTTP Range requests (rare but possible). The standard extractor is the fallback that works everywhere because it streams the entire layer.

--- a/README.md
+++ b/README.md
@@ -151,95 +151,6 @@ Instead of mounting the image, oci-extract:
 - Falls back to streaming decompression (less efficient)
 - Still avoids pulling the entire image into local storage
 
-## Development
-
-### Project Structure
-
-```
-oci-extract/
-├── cmd/                    # CLI commands
-│   ├── root.go            # Root command
-│   ├── extract.go         # Extract command
-│   └── list.go            # List command
-├── internal/
-│   ├── remote/            # HTTP Range request handler
-│   │   └── reader.go
-│   ├── registry/          # Registry client
-│   │   └── client.go
-│   ├── estargz/           # eStargz support
-│   │   └── extractor.go
-│   ├── soci/              # SOCI support
-│   │   ├── discovery.go
-│   │   └── extractor.go
-│   ├── detector/          # Format detection
-│   │   └── format.go
-│   └── extractor/         # Orchestration logic
-│       └── orchestrator.go
-├── main.go
-└── go.mod
-```
-
-### Building
-
-This project uses [mise](https://mise.jdx.dev/) for development tool management and task running.
-
-```bash
-# Install development tools (Go, golangci-lint)
-mise install
-
-# Build the binary (for development)
-mise run build
-
-# Build with version stamping and optimizations (for release)
-mise run build-release
-```
-
-### Running Tests
-
-**Unit Tests** (fast, no external dependencies):
-```bash
-# Run all unit tests
-mise run test
-
-# Run with coverage report
-mise run test-coverage
-```
-
-**Integration Tests** (requires Docker):
-```bash
-# Run integration tests (builds images, converts formats, tests extraction)
-# This task installs nerdctl and soci automatically
-mise run integration-test
-
-# See tests/integration/README.md for more details
-```
-
-### Available Tasks
-
-Run `mise tasks` to see all available tasks:
-
-```bash
-mise tasks
-```
-
-Common tasks:
-- `mise run build` - Build the binary
-- `mise run build-release` - Build with version stamping and optimizations
-- `mise run test` - Run unit tests
-- `mise run integration-test` - Run integration tests (requires Docker)
-- `mise run lint` - Run linter
-- `mise run fmt` - Format code
-- `mise run clean` - Remove build artifacts
-- `mise run deps` - Download dependencies
-- `mise deadcode` - Check for unreachable functions
-
-### Adding New Format Support
-
-1. Create a new package under `internal/`
-2. Implement the extraction logic
-3. Add format detection in `internal/detector/`
-4. Wire it into the orchestrator
-
 ## Performance Comparison
 
 ### File Extraction
@@ -274,13 +185,7 @@ For listing all files in a typical image:
 
 ## Contributing
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests
-5. Submit a pull request
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development setup, workflow, and guidelines.
 
 ## License
 


### PR DESCRIPTION
- Move Development section from README.md to CONTRIBUTING.md
- Update all build/test commands to use mise instead of make
- Add comprehensive CLAUDE.md with architecture overview and design decisions
- Simplify README.md Contributing section to reference CONTRIBUTING.md
- Add detailed task list and testing instructions in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)