### PR TITLE
Build integration test images in zstd formats

### DIFF
--- a/test-images/README.md
+++ b/test-images/README.md
@@ -70,6 +70,42 @@ sudo nerdctl image convert \
 sudo nerdctl push ghcr.io/YOUR_USERNAME/oci-extract-test:estargz
 ```
 
+### Converting to zstd
+
+Using nerdctl (requires sudo to access Docker's containerd):
+```bash
+# Pull the standard image first
+sudo nerdctl pull ghcr.io/YOUR_USERNAME/oci-extract-test:standard
+
+# Convert to zstd
+sudo nerdctl image convert \
+  --zstd \
+  --oci \
+  ghcr.io/YOUR_USERNAME/oci-extract-test:standard \
+  ghcr.io/YOUR_USERNAME/oci-extract-test:zstd
+
+# Push zstd image
+sudo nerdctl push ghcr.io/YOUR_USERNAME/oci-extract-test:zstd
+```
+
+### Converting to zstd:chunked
+
+Using nerdctl (requires sudo to access Docker's containerd):
+```bash
+# Pull the standard image first
+sudo nerdctl pull ghcr.io/YOUR_USERNAME/oci-extract-test:standard
+
+# Convert to zstd:chunked
+sudo nerdctl image convert \
+  --zstdchunked \
+  --oci \
+  ghcr.io/YOUR_USERNAME/oci-extract-test:standard \
+  ghcr.io/YOUR_USERNAME/oci-extract-test:zstd-chunked
+
+# Push zstd:chunked image
+sudo nerdctl push ghcr.io/YOUR_USERNAME/oci-extract-test:zstd-chunked
+```
+
 ### Creating SOCI Indices
 
 Using SOCI CLI (requires sudo to access containerd socket):
@@ -109,8 +145,10 @@ The integration tests (written in Go) automatically:
 2. Build standard Docker images using these Dockerfiles
 3. Convert to eStargz format (if nerdctl available)
 4. Create SOCI indices (if soci available)
-5. Push all variants to GHCR
-6. Run extraction tests against all formats
+5. Convert to zstd format (if nerdctl available)
+6. Convert to zstd:chunked format (if nerdctl available)
+7. Push all variants to GHCR
+8. Run extraction tests against all formats
 
 This approach keeps the image building logic in the test code, making it easier to maintain and modify.
 
@@ -120,9 +158,13 @@ Each test image is tagged with:
 - `standard` - Latest standard OCI image
 - `estargz` - Latest eStargz-converted image
 - `soci` - Latest SOCI-indexed image (same as standard, but with index)
+- `zstd` - Latest zstd-compressed image
+- `zstd-chunked` - Latest zstd:chunked-converted image
 - `multilayer-standard` - Multi-layer standard image
 - `multilayer-estargz` - Multi-layer eStargz image
 - `multilayer-soci` - Multi-layer SOCI-indexed image
+- `multilayer-zstd` - Multi-layer zstd-compressed image
+- `multilayer-zstd-chunked` - Multi-layer zstd:chunked image
 - `{format}-{git-sha}` - Specific commit version
 
 ## Maintenance

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -5,7 +5,7 @@ Integration tests for OCI-Extract that validate extraction functionality against
 ## Overview
 
 These tests validate:
-- Format detection (Standard, eStargz, SOCI)
+- Format detection (Standard, eStargz, SOCI, zstd, zstd:chunked)
 - File extraction from all formats
 - Multi-layer image handling
 - Error cases (file not found, invalid images)
@@ -22,6 +22,8 @@ The integration tests use **prebuilt test images** hosted in GitHub Container Re
 - Builds Docker test images
 - Converts images to eStargz format (using nerdctl)
 - Creates SOCI indices (using soci CLI)
+- Converts images to zstd format (using nerdctl)
+- Converts images to zstd:chunked format (using nerdctl)
 - Pushes all variants to GitHub Container Registry
 - **Runs only in CI** (requires write permissions to ghcr.io)
 
@@ -129,6 +131,8 @@ tests/integration/
 - Correctly identifies Standard OCI layers
 - Correctly identifies eStargz layers (magic footer detection)
 - Correctly identifies SOCI-indexed layers (index discovery)
+- Correctly identifies zstd compressed layers
+- Correctly identifies zstd:chunked layers
 
 ### Extraction Tests
 
@@ -278,8 +282,12 @@ Based on architecture and real-world testing:
 | Standard | ~2s (full layer) | ~2-5s | 1x baseline |
 | eStargz | ~0.3s (~150KB) | ~1.1s (~1.2MB) | 3-4x |
 | SOCI | ~0.4s (~200KB) | ~1.2s (~1.3MB) | 2-3x |
+| zstd | ~2s (full layer) | ~2-5s | 1x (better compression) |
+| zstd:chunked | ~0.3s (~150KB) | ~1.1s (~1.2MB) | 3-4x |
 
 *Actual results depend on network speed, registry performance, and layer size.*
+*Note: zstd provides better compression than gzip but requires streaming full layer like standard format.*
+*zstd:chunked combines zstd compression with chunked access similar to eStargz.*
 
 ## References
 


### PR DESCRIPTION
Add support for building integration test images in zstd and zstd:chunked compression formats to prepare for future extraction support.

Changes:
- Add convertToZstd() function to build zstd-compressed test images
- Add convertToZstdChunked() function to build zstd:chunked test images
- Update integration test README to document new formats
- Update test-images README with conversion examples
- Add performance expectations for zstd formats

The zstd format provides better compression than gzip but still requires streaming the full layer. The zstd:chunked format combines zstd compression with chunked access similar to eStargz, enabling efficient partial downloads.

Both formats are converted using nerdctl's image convert command with the --zstd and --zstdchunked flags respectively.