### PR TITLE
Export GOPROXY

### DIFF
--- a/.claude/scripts/session_start.sh
+++ b/.claude/scripts/session_start.sh
@@ -68,4 +68,7 @@ else
     fi
 fi
 
+# Immediately export variables for current session and child processes
+export GOPROXY=direct
+
 echo "Session start script completed."


### PR DESCRIPTION
The session_start.sh script was correctly adding GOPROXY=direct to ~/.bashrc, but the environment variable wasn't immediately available to child processes. Added explicit export at the end of the script to ensure GOPROXY is available in the current session and all child processes spawned by subsequent commands.