### PR TITLE
Add build dependencies to test tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,6 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v3
 
-      - name: Build oci-extract binary
-        run: mise run build-release
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -156,9 +153,6 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@v3
-
-      - name: Build oci-extract binary
-        run: mise run build-release
 
       - name: Run benchmark
         env:

--- a/mise.toml
+++ b/mise.toml
@@ -64,6 +64,7 @@ go tool cover -html=coverage.out -o coverage.html
 
 [tasks."integration-test"]
 description = "Run integration tests using prebuilt images from registry"
+depends = ["build-release"]
 run = 'go test -v -tags=integration -timeout=30m ./tests/integration/...'
 
 [tasks."integration-test-build-images"]
@@ -72,6 +73,7 @@ run = 'go run -tags=integration ./tests/integration/cmd/build-images'
 
 [tasks.benchmark]
 description = "Run extraction performance benchmarks"
+depends = ["build-release"]
 run = 'go run ./tests/benchmark'
 
 # Clean task


### PR DESCRIPTION
…sts and benchmarks

Add `depends = ["build-release"]` to the integration-test and benchmark tasks in mise.toml so that mise automatically runs the build step before these tasks. This simplifies the CI workflow by removing explicit build steps from the integration-tests and benchmark jobs in ci.yml.

Changes:
- mise.toml: Add depends configuration to integration-test and benchmark tasks
- ci.yml: Remove redundant "Build oci-extract binary" steps

Verified with `mise run --dry-run` that dependencies execute correctly.