### PR TITLE
fix(ci): Use native runners for release builds to fix CGO cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,21 +240,27 @@ jobs:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
     needs: version
     if: needs.version.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - goos: linux
+          - os: ubuntu-latest
+            goos: linux
             goarch: amd64
-          - goos: linux
+          - os: ubuntu-24.04-arm
+            goos: linux
             goarch: arm64
-          - goos: darwin
+          - os: macos-13
+            goos: darwin
             goarch: amd64
-          - goos: darwin
+          - os: macos-latest
+            goos: darwin
             goarch: arm64
-          - goos: windows
+          - os: windows-latest
+            goos: windows
             goarch: amd64
-          - goos: windows
+          - os: windows-11-arm
+            goos: windows
             goarch: arm64
     steps:
       - name: Checkout code


### PR DESCRIPTION
The linux-arm64 release build was failing with "undefined: newGzipZinfo" because soci-snapshotter requires CGO for gzip decompression, which doesn't work when cross-compiling from amd64 to arm64 without a complex toolchain setup.

Solution: Use native runners for each OS/arch combination, matching our integration test approach. This:
- Eliminates cross-compilation complexity
- Ensures consistent build environment between tests and releases
- Fixes the linux-arm64 build failure
- Makes all platform builds more reliable

🤖 Generated with [Claude Code](https://claude.com/claude-code)