### PR TITLE
Add missing permissions for opencode action

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -15,6 +15,9 @@ jobs:
       startsWith(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
     permissions:
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Add contents: write for git operations and checkout extraheader
- Add pull-requests: write for PR commenting
- Add issues: write for issue commenting
- Keep id-token: write for OIDC authentication

This should resolve the git config error where http.https://github.com/.extraheader is not found, as actions/checkout only sets this config when contents: write is specified.